### PR TITLE
Implemented Thundering Herd Protection

### DIFF
--- a/client.go
+++ b/client.go
@@ -28,12 +28,17 @@ type Client struct {
 	// baseURLOauth is the base URL for the OAuth 2.0 token endpoint.
 	baseURLOauth string
 	// scope defines the permission scope for the access token.
-	scope       string
-	apiKey      string
-	mu          sync.RWMutex
-	wg          *sync.WaitGroup
-	accessToken *tokenResponse
-	ctxCancel   context.CancelFunc
+	scope          string
+	apiKey         string
+	mu             sync.RWMutex
+	wg             *sync.WaitGroup
+	accessToken    *tokenResponse
+	ctxCancel      context.CancelFunc
+	refreshMu      sync.Mutex
+	refreshing     bool
+	refreshWaiters []chan error
+	// for testing
+	oauthCreateFunc func(ctx context.Context) (*tokenResponse, error)
 }
 
 // Option is a function type used to configure a Client.


### PR DESCRIPTION
Похоже да проблема есть и надеюсь это поможет исправить:

### Основные изменения

1. **Реализована защита от эффекта "Thundering Herd" при обновлении токена**
   - В структуру `Client` добавлены поля:
     - `refreshMu sync.Mutex`
     - `refreshing bool`
     - `refreshWaiters []chan error`
     - `oauthCreateFunc func(ctx context.Context) (*tokenResponse, error)` (для тестируемости)
   - Теперь если несколько горутин одновременно вызывают `refreshToken`, только одна из них реально выполняет запрос к OAuth, а остальные ждут результат через канал. После завершения обновления все ожидающие получают результат (успех или ошибку).

2. **Рефакторинг для тестируемости**
   - Введено поле `oauthCreateFunc` в структуре `Client`, позволяющее подменять функцию получения токена в тестах (dependency injection).

3. **Добавлен unit-тест на конкурентный refresh**
   - Новый тест `TestClient_ConcurrentRefreshToken` проверяет, что при одновременном вызове `refreshToken` из нескольких горутин реальный запрос к OAuth выполняется только один раз, а все горутины получают одинаковый результат.
   - Для этого используется подмена `oauthCreateFunc` и счетчик вызовов через `atomic`.

